### PR TITLE
Feature - Modernized Help Output Formatting and Ordering

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -48,12 +48,6 @@ type flagSet struct {
 	requestedVersion bool
 }
 
-func (f *flagSet) VisitAll(fn func(*flag.Flag)) {
-	if vf, ok := f.Flags.(visitAllFlagger); ok {
-		vf.VisitAll(fn)
-	}
-}
-
 func createDefaultFlags(name string) *flag.FlagSet {
 	return flag.NewFlagSet(name, flag.ContinueOnError)
 }
@@ -133,7 +127,6 @@ type flagInfo struct {
 	shorthand string
 	usage     string
 	defValue  string
-	value     flag.Value
 	typeName  string
 }
 
@@ -145,30 +138,19 @@ func (a *app) printFlagDefaults(flags Flags) {
 		inner = fs.Flags
 	}
 
-	var others []flagInfo
-	var version *flagInfo
-	var help *flagInfo
-
-	// Visit all flags and categorize them
-	visited := visitFlags(inner, func(f flagInfo) {
-		switch f.name {
-		case "help":
-			help = &f
-		case "version":
-			version = &f
-		default:
-			others = append(others, f)
-		}
-	})
+	// Visit and categorize flags for reordering
+	userFlags, version, help, visited := categorizeFlagsByName(inner)
 
 	if !visited {
-		// Fallback to default printing if we can't visit
+		if out := flags.Output(); out != nil {
+			fmt.Fprintf(out, "\nOptions:\n\n")
+		}
 		flags.PrintDefaults()
 		return
 	}
 
-	// Build the ordered list: others, then version, then help
-	all := others
+	// Order entries: user flags first, then version, then help last
+	all := userFlags
 	if version != nil {
 		all = append(all, *version)
 	}
@@ -180,12 +162,16 @@ func (a *app) printFlagDefaults(flags Flags) {
 		return
 	}
 
-	// Determine dash prefix and check for shorthands
+	// Determine dash prefix based on the flag implementation.
+	// Standard library flag uses single-dash, while other implementations
+	// (like spf13/pflag) use double-dash by convention.
 	dashPrefix := "--"
-	hasShorthands := false
 	if _, isStd := inner.(*flag.FlagSet); isStd {
 		dashPrefix = "-"
 	}
+
+	// Check if any flags have shorthands to decide on column layout
+	hasShorthands := false
 	for _, f := range all {
 		if f.shorthand != "" {
 			hasShorthands = true
@@ -193,50 +179,71 @@ func (a *app) printFlagDefaults(flags Flags) {
 		}
 	}
 
-	// Calculate flag entries and their max length for alignment
+	// Format flag names and calculate max width for tab-stop alignment
 	maxLen := 0
-	formattedParts := make([]string, len(all))
+	formattedNames := make([]string, len(all))
 	for i, f := range all {
-		var sb strings.Builder
-
-		// Shorthand column
-		if hasShorthands {
-			if f.shorthand != "" {
-				fmt.Fprintf(&sb, "-%s, ", f.shorthand)
-			} else {
-				sb.WriteString("    ")
-			}
-		}
-
-		// Flag name
-		sb.WriteString(dashPrefix)
-		sb.WriteString(f.name)
-
-		// Type name
-		if f.typeName != "" && f.typeName != "bool" {
-			sb.WriteString(" ")
-			sb.WriteString(f.typeName)
-		}
-
-		formattedParts[i] = sb.String()
-		if len(formattedParts[i]) > maxLen {
-			maxLen = len(formattedParts[i])
+		formattedNames[i] = formatFlagName(f, dashPrefix, hasShorthands)
+		if len(formattedNames[i]) > maxLen {
+			maxLen = len(formattedNames[i])
 		}
 	}
 
-	// Print the output with tab alignment
-	fmt.Fprintf(flags.Output(), "\nOptions:\n\n")
+	// Print standardized, tab-aligned options
+	out := flags.Output()
+	fmt.Fprintf(out, "\nOptions:\n\n")
 	for i, f := range all {
-		fmt.Fprintf(flags.Output(), "\t%-[1]*s\t%s", maxLen, formattedParts[i], f.usage)
+		fmt.Fprintf(out, "\t%-[1]*s\t%s", maxLen, formattedNames[i], f.usage)
+
+		// Print default value if it's non-zero
 		if f.defValue != "" && f.defValue != "false" && f.defValue != "0" && f.defValue != `""` {
 			def := f.defValue
-			if f.typeName == "string" && !strings.HasPrefix(def, `"`) {
+			if (f.typeName == "string" || f.typeName == "") && !strings.HasPrefix(def, `"`) {
 				def = fmt.Sprintf("%q", def)
 			}
-			fmt.Fprintf(flags.Output(), " (default %s)", def)
+			fmt.Fprintf(out, " (default %s)", def)
 		}
-		fmt.Fprintln(flags.Output())
+		fmt.Fprintln(out)
 	}
+}
+
+// categorizeFlagsByName visits all flags and separates them into user-defined
+// flags, and the special version and help flags.
+func categorizeFlagsByName(flags Flags) (userFlags []flagInfo, version, help *flagInfo, visited bool) {
+	visited = visitFlags(flags, func(f flagInfo) {
+		switch f.name {
+		case "help":
+			help = &f
+		case "version":
+			version = &f
+		default:
+			userFlags = append(userFlags, f)
+		}
+	})
+	return
+}
+
+// formatFlagName formats the name portion of a flag for display, including
+// shorthand, prefix, and type information.
+func formatFlagName(f flagInfo, dashPrefix string, hasShorthands bool) string {
+	var sb strings.Builder
+
+	if hasShorthands {
+		if f.shorthand != "" {
+			fmt.Fprintf(&sb, "-%s, ", f.shorthand)
+		} else {
+			sb.WriteString("    ")
+		}
+	}
+
+	sb.WriteString(dashPrefix)
+	sb.WriteString(f.name)
+
+	if f.typeName != "" && f.typeName != "bool" {
+		fmt.Fprintf(&sb, " %s", f.typeName)
+	}
+
+	return sb.String()
 }
 
 // visitFlags attempts to visit all flags in a generic way, supporting both
@@ -250,7 +257,6 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 				name:     f.Name,
 				usage:    usage,
 				defValue: f.DefValue,
-				value:    f.Value,
 				typeName: typeName,
 			})
 		})
@@ -261,7 +267,6 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 	v := reflect.ValueOf(flags)
 	m := v.MethodByName("VisitAll")
 	if !m.IsValid() {
-		// Try the underlying value if it's an interface or pointer
 		for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 			v = v.Elem()
 			m = v.MethodByName("VisitAll")
@@ -275,12 +280,17 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 		return false
 	}
 
-	// Create a generic callback for the VisitAll method
 	callbackType := m.Type().In(0)
+	if callbackType.Kind() != reflect.Func {
+		return false
+	}
+
 	callback := reflect.MakeFunc(callbackType, func(args []reflect.Value) []reflect.Value {
 		f := reflect.Indirect(args[0])
+		if f.Kind() != reflect.Struct {
+			return nil
+		}
 
-		// Helper to safely get a string field
 		getStr := func(name string) string {
 			field := f.FieldByName(name)
 			if field.IsValid() && field.Kind() == reflect.String {
@@ -297,13 +307,7 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 		}
 
 		if valField := f.FieldByName("Value"); valField.IsValid() {
-			val := valField.Interface()
-			if v, ok := val.(flag.Value); ok {
-				info.value = v
-			}
-
-			// Try to get the type name (common in libraries like pflag)
-			if tv, ok := val.(interface{ Type() string }); ok {
+			if tv, ok := valField.Interface().(interface{ Type() string }); ok {
 				info.typeName = tv.Type()
 			}
 		}

--- a/flags.go
+++ b/flags.go
@@ -43,6 +43,12 @@ type flagSet struct {
 	requestedVersion bool
 }
 
+func (f *flagSet) VisitAll(fn func(*flag.Flag)) {
+	if vf, ok := f.Flags.(visitAllFlagger); ok {
+		vf.VisitAll(fn)
+	}
+}
+
 func createDefaultFlags(name string) *flag.FlagSet {
 	return flag.NewFlagSet(name, flag.ContinueOnError)
 }
@@ -118,11 +124,143 @@ func (a *app) setupFlagSet(flagSet *flagSet, isRoot bool) {
 
 // printFlagDefaults wraps the writing of flag default values
 func (a *app) printFlagDefaults(flags Flags) {
+	if fs, ok := flags.(*flagSet); ok {
+		flags = fs.Flags
+	}
+
 	var buffer bytes.Buffer
 	originalOut := flags.Output()
 
 	flags.SetOutput(&buffer)
-	flags.PrintDefaults()
+
+	// Function to visit flags generically using reflection if necessary
+	visitAll := func(fn func(name, usage, defValue string, value flag.Value)) bool {
+		// Try standard interface first
+		if vf, ok := flags.(visitAllFlagger); ok {
+			vf.VisitAll(func(f *flag.Flag) {
+				fn(f.Name, f.Usage, f.DefValue, f.Value)
+			})
+			return true
+		}
+
+		// Use reflection for other implementations (like pflag)
+		v := reflect.ValueOf(flags)
+		m := v.MethodByName("VisitAll")
+		if !m.IsValid() {
+			// Try the underlying value if it's an interface or pointer
+			for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+				v = v.Elem()
+				m = v.MethodByName("VisitAll")
+				if m.IsValid() {
+					break
+				}
+			}
+		}
+
+		if !m.IsValid() {
+			return false
+		}
+
+		mType := m.Type()
+		if mType.NumIn() != 1 {
+			return false
+		}
+
+		callbackType := mType.In(0)
+		if callbackType.Kind() != reflect.Func || callbackType.NumIn() != 1 {
+			return false
+		}
+
+		callback := reflect.MakeFunc(callbackType, func(args []reflect.Value) []reflect.Value {
+			f := args[0]
+			for f.Kind() == reflect.Pointer || f.Kind() == reflect.Interface {
+				f = f.Elem()
+			}
+
+			// Helper to get string field if it exists
+			getString := func(name string) string {
+				field := f.FieldByName(name)
+				if field.IsValid() && field.Kind() == reflect.String {
+					return field.String()
+				}
+				return ""
+			}
+
+			name := getString("Name")
+			usage := getString("Usage")
+			defValue := getString("DefValue")
+
+			// Get Value field
+			var val flag.Value
+			valField := f.FieldByName("Value")
+			if valField.IsValid() {
+				if v, ok := valField.Interface().(flag.Value); ok {
+					val = v
+				}
+			}
+
+			if name != "" {
+				fn(name, usage, defValue, val)
+			}
+
+			return nil
+		})
+
+		m.Call([]reflect.Value{callback})
+		return true
+	}
+
+	type flagInfo struct {
+		name     string
+		usage    string
+		defValue string
+		value    flag.Value
+	}
+
+	var others []flagInfo
+	var version *flagInfo
+	var help []flagInfo
+
+	visited := visitAll(func(name, usage, defValue string, value flag.Value) {
+		info := flagInfo{name, usage, defValue, value}
+		switch name {
+		case "help", "h":
+			help = append(help, info)
+		case "version":
+			version = &info
+		default:
+			others = append(others, info)
+		}
+	})
+	if visited {
+		// Helper to print a group of flags using a temporary FlagSet to
+		// maintain the standard library's formatting
+		printGroup := func(group []flagInfo) {
+			if len(group) == 0 {
+				return
+			}
+
+			temp := flag.NewFlagSet("", flag.ContinueOnError)
+			temp.SetOutput(&buffer)
+
+			for _, f := range group {
+				temp.Var(f.value, f.name, f.usage)
+				temp.Lookup(f.name).DefValue = f.defValue
+			}
+
+			temp.PrintDefaults()
+		}
+
+		printGroup(others)
+		if version != nil {
+			printGroup([]flagInfo{*version})
+		}
+		printGroup(help)
+
+	} else {
+		// Fallback to default printing if we can't visit
+		flags.PrintDefaults()
+	}
 
 	if buffer.Len() > 0 {
 		// Only write a header if the printing of defaults actually wrote bytes

--- a/flags.go
+++ b/flags.go
@@ -32,6 +32,11 @@ type lookupVarFlagger interface {
 	Var(value flag.Value, name string, usage string)
 }
 
+// visitAllFlagger defines an interface for visiting all set flags.
+//
+// This interface is specifically designed for compatibility with the Go
+// standard library's flag package. Other techniques (such as reflection) are
+// employed to support similar functionality in other flag packages.
 type visitAllFlagger interface {
 	VisitAll(fn func(*flag.Flag))
 }
@@ -122,8 +127,17 @@ func (a *app) setupFlagSet(flagSet *flagSet, isRoot bool) {
 	}
 }
 
+// flagInfo normalizes flag data across different flag library implementations
+type flagInfo struct {
+	name     string
+	usage    string
+	defValue string
+	value    flag.Value
+}
+
 // printFlagDefaults wraps the writing of flag default values
 func (a *app) printFlagDefaults(flags Flags) {
+	// Unwrap our internal flagSet if necessary
 	if fs, ok := flags.(*flagSet); ok {
 		flags = fs.Flags
 	}
@@ -133,105 +147,22 @@ func (a *app) printFlagDefaults(flags Flags) {
 
 	flags.SetOutput(&buffer)
 
-	// Function to visit flags generically using reflection if necessary
-	visitAll := func(fn func(name, usage, defValue string, value flag.Value)) bool {
-		// Try standard interface first
-		if vf, ok := flags.(visitAllFlagger); ok {
-			vf.VisitAll(func(f *flag.Flag) {
-				fn(f.Name, f.Usage, f.DefValue, f.Value)
-			})
-			return true
-		}
-
-		// Use reflection for other implementations (like pflag)
-		v := reflect.ValueOf(flags)
-		m := v.MethodByName("VisitAll")
-		if !m.IsValid() {
-			// Try the underlying value if it's an interface or pointer
-			for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
-				v = v.Elem()
-				m = v.MethodByName("VisitAll")
-				if m.IsValid() {
-					break
-				}
-			}
-		}
-
-		if !m.IsValid() {
-			return false
-		}
-
-		mType := m.Type()
-		if mType.NumIn() != 1 {
-			return false
-		}
-
-		callbackType := mType.In(0)
-		if callbackType.Kind() != reflect.Func || callbackType.NumIn() != 1 {
-			return false
-		}
-
-		callback := reflect.MakeFunc(callbackType, func(args []reflect.Value) []reflect.Value {
-			f := args[0]
-			for f.Kind() == reflect.Pointer || f.Kind() == reflect.Interface {
-				f = f.Elem()
-			}
-
-			// Helper to get string field if it exists
-			getString := func(name string) string {
-				field := f.FieldByName(name)
-				if field.IsValid() && field.Kind() == reflect.String {
-					return field.String()
-				}
-				return ""
-			}
-
-			name := getString("Name")
-			usage := getString("Usage")
-			defValue := getString("DefValue")
-
-			// Get Value field
-			var val flag.Value
-			valField := f.FieldByName("Value")
-			if valField.IsValid() {
-				if v, ok := valField.Interface().(flag.Value); ok {
-					val = v
-				}
-			}
-
-			if name != "" {
-				fn(name, usage, defValue, val)
-			}
-
-			return nil
-		})
-
-		m.Call([]reflect.Value{callback})
-		return true
-	}
-
-	type flagInfo struct {
-		name     string
-		usage    string
-		defValue string
-		value    flag.Value
-	}
-
 	var others []flagInfo
 	var version *flagInfo
 	var help []flagInfo
 
-	visited := visitAll(func(name, usage, defValue string, value flag.Value) {
-		info := flagInfo{name, usage, defValue, value}
-		switch name {
+	// Visit all flags and categorize them
+	visited := visitFlags(flags, func(f flagInfo) {
+		switch f.name {
 		case "help", "h":
-			help = append(help, info)
+			help = append(help, f)
 		case "version":
-			version = &info
+			version = &f
 		default:
-			others = append(others, info)
+			others = append(others, f)
 		}
 	})
+
 	if visited {
 		// Helper to print a group of flags using a temporary FlagSet to
 		// maintain the standard library's formatting
@@ -272,4 +203,71 @@ func (a *app) printFlagDefaults(flags Flags) {
 
 	// Restore the original output
 	flags.SetOutput(originalOut)
+}
+
+// visitFlags attempts to visit all flags in a generic way, supporting both
+// the standard library and third-party libraries (via reflection).
+func visitFlags(flags Flags, fn func(flagInfo)) bool {
+	// 1. Try standard library visitor pattern
+	if vf, ok := flags.(visitAllFlagger); ok {
+		vf.VisitAll(func(f *flag.Flag) {
+			fn(flagInfo{f.Name, f.Usage, f.DefValue, f.Value})
+		})
+		return true
+	}
+
+	// 2. Try reflection for other implementations (like pflag)
+	v := reflect.ValueOf(flags)
+	m := v.MethodByName("VisitAll")
+	if !m.IsValid() {
+		// Try the underlying value if it's an interface or pointer
+		for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+			v = v.Elem()
+			m = v.MethodByName("VisitAll")
+			if m.IsValid() {
+				break
+			}
+		}
+	}
+
+	if !m.IsValid() || m.Type().NumIn() != 1 {
+		return false
+	}
+
+	// Create a generic callback for the VisitAll method
+	callbackType := m.Type().In(0)
+	callback := reflect.MakeFunc(callbackType, func(args []reflect.Value) []reflect.Value {
+		f := reflect.Indirect(args[0])
+
+		// Helper to safely get a string field or value
+		get := func(name string) string {
+			field := f.FieldByName(name)
+			if field.IsValid() && field.Kind() == reflect.String {
+				return field.String()
+			}
+			return ""
+		}
+
+		// Extract flag data using reflection
+		info := flagInfo{
+			name:     get("Name"),
+			usage:    get("Usage"),
+			defValue: get("DefValue"),
+		}
+
+		if valField := f.FieldByName("Value"); valField.IsValid() {
+			if val, ok := valField.Interface().(flag.Value); ok {
+				info.value = val
+			}
+		}
+
+		if info.name != "" {
+			fn(info)
+		}
+
+		return nil
+	})
+
+	m.Call([]reflect.Value{callback})
+	return true
 }

--- a/flags.go
+++ b/flags.go
@@ -257,7 +257,7 @@ func formatFlagName(f flagInfo, dashPrefix string, hasShorthands bool) string {
 // visitFlags attempts to visit all flags in a generic way, supporting both
 // the standard library and third-party libraries (via reflection).
 func visitFlags(flags Flags, fn func(flagInfo)) bool {
-	// 1. Try standard library visitor pattern
+	// Try standard library visitor pattern
 	if vf, ok := flags.(visitAllFlagger); ok {
 		vf.VisitAll(func(f *flag.Flag) {
 			typeName, usage := flag.UnquoteUsage(f)
@@ -271,7 +271,7 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 		return true
 	}
 
-	// 2. Try reflection for other implementations (like pflag)
+	// Otherwise, try reflection for other implementations (like pflag)
 	m := reflect.ValueOf(flags).MethodByName("VisitAll")
 	if !m.IsValid() || m.Type().NumIn() != 1 {
 		return false

--- a/flags.go
+++ b/flags.go
@@ -133,6 +133,7 @@ type flagInfo struct {
 	usage    string
 	defValue string
 	value    flag.Value
+	typeName string
 }
 
 // printFlagDefaults wraps the writing of flag default values
@@ -165,7 +166,7 @@ func (a *app) printFlagDefaults(flags Flags) {
 
 	if visited {
 		// Helper to print a group of flags using a temporary FlagSet to
-		// maintain the standard library's formatting
+		// maintain the standard library's formatting and alignment
 		printGroup := func(group []flagInfo) {
 			if len(group) == 0 {
 				return
@@ -175,7 +176,12 @@ func (a *app) printFlagDefaults(flags Flags) {
 			temp.SetOutput(&buffer)
 
 			for _, f := range group {
-				temp.Var(f.value, f.name, f.usage)
+				usage := f.usage
+				if f.typeName != "" && f.typeName != "bool" {
+					usage = fmt.Sprintf("`%s` %s", f.typeName, usage)
+				}
+
+				temp.Var(f.value, f.name, usage)
 				temp.Lookup(f.name).DefValue = f.defValue
 			}
 
@@ -211,7 +217,8 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 	// 1. Try standard library visitor pattern
 	if vf, ok := flags.(visitAllFlagger); ok {
 		vf.VisitAll(func(f *flag.Flag) {
-			fn(flagInfo{f.Name, f.Usage, f.DefValue, f.Value})
+			_, usage := flag.UnquoteUsage(f)
+			fn(flagInfo{f.Name, usage, f.DefValue, f.Value, ""})
 		})
 		return true
 	}
@@ -221,7 +228,7 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 	m := v.MethodByName("VisitAll")
 	if !m.IsValid() {
 		// Try the underlying value if it's an interface or pointer
-		for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 			v = v.Elem()
 			m = v.MethodByName("VisitAll")
 			if m.IsValid() {
@@ -240,7 +247,7 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 		f := reflect.Indirect(args[0])
 
 		// Helper to safely get a string field or value
-		get := func(name string) string {
+		getString := func(name string) string {
 			field := f.FieldByName(name)
 			if field.IsValid() && field.Kind() == reflect.String {
 				return field.String()
@@ -250,14 +257,21 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 
 		// Extract flag data using reflection
 		info := flagInfo{
-			name:     get("Name"),
-			usage:    get("Usage"),
-			defValue: get("DefValue"),
+			name:     getString("Name"),
+			usage:    getString("Usage"),
+			defValue: getString("DefValue"),
 		}
 
 		if valField := f.FieldByName("Value"); valField.IsValid() {
-			if val, ok := valField.Interface().(flag.Value); ok {
-				info.value = val
+			val := valField.Interface()
+
+			if v, ok := val.(flag.Value); ok {
+				info.value = v
+			}
+
+			// Try to get the type name (common in libraries like pflag)
+			if tv, ok := val.(interface{ Type() string }); ok {
+				info.typeName = tv.Type()
 			}
 		}
 

--- a/flags.go
+++ b/flags.go
@@ -3,11 +3,11 @@
 package lieut
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 )
 
 // Flags defines an interface for command flags.
@@ -127,36 +127,33 @@ func (a *app) setupFlagSet(flagSet *flagSet, isRoot bool) {
 	}
 }
 
-// flagInfo normalizes flag data across different flag library implementations
+// flagInfo normalizes flag data across different flag library implementations.
 type flagInfo struct {
-	name     string
-	usage    string
-	defValue string
-	value    flag.Value
-	typeName string
+	name      string
+	shorthand string
+	usage     string
+	defValue  string
+	value     flag.Value
+	typeName  string
 }
 
-// printFlagDefaults wraps the writing of flag default values
+// printFlagDefaults wraps the writing of flag default values.
 func (a *app) printFlagDefaults(flags Flags) {
 	// Unwrap our internal flagSet if necessary
+	inner := flags
 	if fs, ok := flags.(*flagSet); ok {
-		flags = fs.Flags
+		inner = fs.Flags
 	}
-
-	var buffer bytes.Buffer
-	originalOut := flags.Output()
-
-	flags.SetOutput(&buffer)
 
 	var others []flagInfo
 	var version *flagInfo
-	var help []flagInfo
+	var help *flagInfo
 
 	// Visit all flags and categorize them
-	visited := visitFlags(flags, func(f flagInfo) {
+	visited := visitFlags(inner, func(f flagInfo) {
 		switch f.name {
-		case "help", "h":
-			help = append(help, f)
+		case "help":
+			help = &f
 		case "version":
 			version = &f
 		default:
@@ -164,51 +161,82 @@ func (a *app) printFlagDefaults(flags Flags) {
 		}
 	})
 
-	if visited {
-		// Helper to print a group of flags using a temporary FlagSet to
-		// maintain the standard library's formatting and alignment
-		printGroup := func(group []flagInfo) {
-			if len(group) == 0 {
-				return
-			}
-
-			temp := flag.NewFlagSet("", flag.ContinueOnError)
-			temp.SetOutput(&buffer)
-
-			for _, f := range group {
-				usage := f.usage
-				if f.typeName != "" && f.typeName != "bool" {
-					usage = fmt.Sprintf("`%s` %s", f.typeName, usage)
-				}
-
-				temp.Var(f.value, f.name, usage)
-				temp.Lookup(f.name).DefValue = f.defValue
-			}
-
-			temp.PrintDefaults()
-		}
-
-		printGroup(others)
-		if version != nil {
-			printGroup([]flagInfo{*version})
-		}
-		printGroup(help)
-
-	} else {
+	if !visited {
 		// Fallback to default printing if we can't visit
 		flags.PrintDefaults()
+		return
 	}
 
-	if buffer.Len() > 0 {
-		// Only write a header if the printing of defaults actually wrote bytes
-		fmt.Fprintf(originalOut, "\nOptions:\n\n")
-
-		// Write the buffered flag output
-		buffer.WriteTo(originalOut)
+	// Build the ordered list: others, then version, then help
+	all := others
+	if version != nil {
+		all = append(all, *version)
+	}
+	if help != nil {
+		all = append(all, *help)
 	}
 
-	// Restore the original output
-	flags.SetOutput(originalOut)
+	if len(all) == 0 {
+		return
+	}
+
+	// Determine dash prefix and check for shorthands
+	dashPrefix := "--"
+	hasShorthands := false
+	if _, isStd := inner.(*flag.FlagSet); isStd {
+		dashPrefix = "-"
+	}
+	for _, f := range all {
+		if f.shorthand != "" {
+			hasShorthands = true
+			break
+		}
+	}
+
+	// Calculate flag entries and their max length for alignment
+	maxLen := 0
+	formattedParts := make([]string, len(all))
+	for i, f := range all {
+		var sb strings.Builder
+
+		// Shorthand column
+		if hasShorthands {
+			if f.shorthand != "" {
+				fmt.Fprintf(&sb, "-%s, ", f.shorthand)
+			} else {
+				sb.WriteString("    ")
+			}
+		}
+
+		// Flag name
+		sb.WriteString(dashPrefix)
+		sb.WriteString(f.name)
+
+		// Type name
+		if f.typeName != "" && f.typeName != "bool" {
+			sb.WriteString(" ")
+			sb.WriteString(f.typeName)
+		}
+
+		formattedParts[i] = sb.String()
+		if len(formattedParts[i]) > maxLen {
+			maxLen = len(formattedParts[i])
+		}
+	}
+
+	// Print the output with tab alignment
+	fmt.Fprintf(flags.Output(), "\nOptions:\n\n")
+	for i, f := range all {
+		fmt.Fprintf(flags.Output(), "\t%-[1]*s\t%s", maxLen, formattedParts[i], f.usage)
+		if f.defValue != "" && f.defValue != "false" && f.defValue != "0" && f.defValue != `""` {
+			def := f.defValue
+			if f.typeName == "string" && !strings.HasPrefix(def, `"`) {
+				def = fmt.Sprintf("%q", def)
+			}
+			fmt.Fprintf(flags.Output(), " (default %s)", def)
+		}
+		fmt.Fprintln(flags.Output())
+	}
 }
 
 // visitFlags attempts to visit all flags in a generic way, supporting both
@@ -217,8 +245,14 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 	// 1. Try standard library visitor pattern
 	if vf, ok := flags.(visitAllFlagger); ok {
 		vf.VisitAll(func(f *flag.Flag) {
-			_, usage := flag.UnquoteUsage(f)
-			fn(flagInfo{f.Name, usage, f.DefValue, f.Value, ""})
+			typeName, usage := flag.UnquoteUsage(f)
+			fn(flagInfo{
+				name:     f.Name,
+				usage:    usage,
+				defValue: f.DefValue,
+				value:    f.Value,
+				typeName: typeName,
+			})
 		})
 		return true
 	}
@@ -228,7 +262,7 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 	m := v.MethodByName("VisitAll")
 	if !m.IsValid() {
 		// Try the underlying value if it's an interface or pointer
-		for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 			v = v.Elem()
 			m = v.MethodByName("VisitAll")
 			if m.IsValid() {
@@ -246,8 +280,8 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 	callback := reflect.MakeFunc(callbackType, func(args []reflect.Value) []reflect.Value {
 		f := reflect.Indirect(args[0])
 
-		// Helper to safely get a string field or value
-		getString := func(name string) string {
+		// Helper to safely get a string field
+		getStr := func(name string) string {
 			field := f.FieldByName(name)
 			if field.IsValid() && field.Kind() == reflect.String {
 				return field.String()
@@ -255,16 +289,15 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 			return ""
 		}
 
-		// Extract flag data using reflection
 		info := flagInfo{
-			name:     getString("Name"),
-			usage:    getString("Usage"),
-			defValue: getString("DefValue"),
+			name:      getStr("Name"),
+			shorthand: getStr("Shorthand"),
+			usage:     getStr("Usage"),
+			defValue:  getStr("DefValue"),
 		}
 
 		if valField := f.FieldByName("Value"); valField.IsValid() {
 			val := valField.Interface()
-
 			if v, ok := val.(flag.Value); ok {
 				info.value = v
 			}

--- a/flags.go
+++ b/flags.go
@@ -3,6 +3,7 @@
 package lieut
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -142,10 +143,17 @@ func (a *app) printFlagDefaults(flags Flags) {
 	userFlags, version, help, visited := categorizeFlagsByName(inner)
 
 	if !visited {
-		if out := flags.Output(); out != nil {
-			fmt.Fprintf(out, "\nOptions:\n\n")
-		}
+		var buffer bytes.Buffer
+		originalOut := flags.Output()
+
+		flags.SetOutput(&buffer)
 		flags.PrintDefaults()
+		flags.SetOutput(originalOut)
+
+		if buffer.Len() > 0 {
+			fmt.Fprintf(originalOut, "\nOptions:\n\n")
+			buffer.WriteTo(originalOut)
+		}
 		return
 	}
 

--- a/flags.go
+++ b/flags.go
@@ -272,18 +272,7 @@ func visitFlags(flags Flags, fn func(flagInfo)) bool {
 	}
 
 	// 2. Try reflection for other implementations (like pflag)
-	v := reflect.ValueOf(flags)
-	m := v.MethodByName("VisitAll")
-	if !m.IsValid() {
-		for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
-			v = v.Elem()
-			m = v.MethodByName("VisitAll")
-			if m.IsValid() {
-				break
-			}
-		}
-	}
-
+	m := reflect.ValueOf(flags).MethodByName("VisitAll")
 	if !m.IsValid() || m.Type().NumIn() != 1 {
 		return false
 	}

--- a/flags_test.go
+++ b/flags_test.go
@@ -169,31 +169,45 @@ func (s *stringVisitAllFlags) VisitAll(fn func(string)) {
 	fn("test-flag")
 }
 
-func TestPrintFlagDefaults_FallbackWithOutput(t *testing.T) {
-	var buf bytes.Buffer
-	flags := &verboseBogusFlags{out: &buf}
+func TestPrintFlagDefaults(t *testing.T) {
+	for testName, testData := range map[string]struct {
+		flags Flags
+		want  string
+	}{
+		"fallback with output": {
+			flags: &verboseBogusFlags{},
+			want:  "\nOptions:\n\n  -someflag\tA flag description\n",
+		},
+		"empty flagset": {
+			flags: flag.NewFlagSet("empty", flag.ContinueOnError),
+			want:  "",
+		},
+		"reflectable flags with shorthands": {
+			flags: &reflectableFlags{
+				flags: []mockReflectFlag{
+					{Name: "output", Shorthand: "o", Usage: "Output file", Value: "string"},
+					{Name: "verbose", Usage: "Enable verbose output", Value: "bool"},
+					{Name: "help", Shorthand: "h", Usage: "Display the help message", Value: "bool"},
+				},
+			},
+			want: "\nOptions:\n\n" +
+				"\t-o, --output string\tOutput file\n" +
+				"\t    --verbose      \tEnable verbose output\n" +
+				"\t-h, --help         \tDisplay the help message\n",
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			var buf bytes.Buffer
+			testData.flags.SetOutput(&buf)
 
-	app := NewSingleCommandApp(testAppInfo, testNoOpExecutor, nil, io.Discard, io.Discard)
-	app.printFlagDefaults(flags)
+			app := NewSingleCommandApp(testAppInfo, testNoOpExecutor, nil, io.Discard, io.Discard)
+			app.printFlagDefaults(testData.flags)
 
-	got := buf.String()
-	want := "\nOptions:\n\n  -someflag\tA flag description\n"
-
-	if got != want {
-		t.Errorf("printFlagDefaults fallback with output gave %q, want %q", got, want)
-	}
-}
-
-func TestPrintFlagDefaults_EmptyFlagSet(t *testing.T) {
-	var buf bytes.Buffer
-	emptyFlags := flag.NewFlagSet("empty", flag.ContinueOnError)
-	emptyFlags.SetOutput(&buf)
-
-	app := NewSingleCommandApp(testAppInfo, testNoOpExecutor, nil, io.Discard, &buf)
-	app.printFlagDefaults(emptyFlags)
-
-	if buf.String() != "" {
-		t.Errorf("printFlagDefaults with empty flagset gave %q, want empty", buf.String())
+			got := buf.String()
+			if got != testData.want {
+				t.Errorf("printFlagDefaults gave %q, want %q", got, testData.want)
+			}
+		})
 	}
 }
 
@@ -241,117 +255,60 @@ func TestFormatFlagName(t *testing.T) {
 	}
 }
 
-func TestVisitFlags_Reflection(t *testing.T) {
-	flags := &reflectableFlags{
-		flags: []mockReflectFlag{
-			{Name: "verbose", Usage: "Enable verbose output", DefValue: "false", Value: "bool"},
-			{Name: "output", Shorthand: "o", Usage: "Output file", Value: "string"},
+func TestVisitFlags(t *testing.T) {
+	for testName, testData := range map[string]struct {
+		flags      Flags
+		wantResult bool
+		wantFlags  []flagInfo
+	}{
+		"reflection": {
+			flags: &reflectableFlags{
+				flags: []mockReflectFlag{
+					{Name: "verbose", Usage: "Enable verbose output", DefValue: "false", Value: "bool"},
+					{Name: "output", Shorthand: "o", Usage: "Output file", Value: "string"},
+				},
+			},
+			wantResult: true,
+			wantFlags: []flagInfo{
+				{name: "verbose", usage: "Enable verbose output", defValue: "false", typeName: "bool"},
+				{name: "output", shorthand: "o", usage: "Output file", typeName: "string"},
+			},
 		},
-	}
-
-	var visited []flagInfo
-	result := visitFlags(flags, func(f flagInfo) {
-		visited = append(visited, f)
-	})
-
-	if !result {
-		t.Fatal("visitFlags returned false for reflectable flags")
-	}
-
-	if len(visited) != 2 {
-		t.Fatalf("visitFlags visited %d flags, want 2", len(visited))
-	}
-
-	if visited[0].name != "verbose" || visited[0].typeName != "bool" {
-		t.Errorf("first flag: got name=%q typeName=%q, want name=%q typeName=%q",
-			visited[0].name, visited[0].typeName, "verbose", "bool")
-	}
-
-	if visited[1].shorthand != "o" || visited[1].typeName != "string" {
-		t.Errorf("second flag: got shorthand=%q typeName=%q, want shorthand=%q typeName=%q",
-			visited[1].shorthand, visited[1].typeName, "o", "string")
-	}
-}
-
-func TestVisitFlags_MissingFields(t *testing.T) {
-	flags := &minimalReflectableFlags{
-		flags: []minimalReflectFlag{
-			{Name: "test"},
+		"missing fields": {
+			flags: &minimalReflectableFlags{
+				flags: []minimalReflectFlag{{Name: "test"}},
+			},
+			wantResult: true,
+			wantFlags:  []flagInfo{{name: "test"}},
 		},
-	}
-
-	var visited []flagInfo
-	result := visitFlags(flags, func(f flagInfo) {
-		visited = append(visited, f)
-	})
-
-	if !result {
-		t.Fatal("visitFlags returned false for minimal reflectable flags")
-	}
-
-	if len(visited) != 1 {
-		t.Fatalf("visitFlags visited %d flags, want 1", len(visited))
-	}
-
-	if visited[0].name != "test" {
-		t.Errorf("flag name: got %q, want %q", visited[0].name, "test")
-	}
-
-	if visited[0].shorthand != "" || visited[0].usage != "" || visited[0].defValue != "" {
-		t.Errorf("flag should have empty fields for missing struct fields, got %+v", visited[0])
-	}
-}
-
-func TestVisitFlags_NonFuncVisitAll(t *testing.T) {
-	flags := &nonFuncVisitAllFlags{}
-
-	result := visitFlags(flags, func(f flagInfo) {
-		t.Error("visitor should not be called")
-	})
-
-	if result {
-		t.Error("visitFlags returned true for non-func VisitAll")
-	}
-}
-
-func TestVisitFlags_NonStructCallback(t *testing.T) {
-	flags := &stringVisitAllFlags{}
-
-	var visited int
-	result := visitFlags(flags, func(f flagInfo) {
-		visited++
-	})
-
-	if !result {
-		t.Error("visitFlags returned false for string VisitAll")
-	}
-
-	if visited != 0 {
-		t.Errorf("visitFlags visited %d flags, want 0 (non-struct args should be skipped)", visited)
-	}
-}
-
-func TestReflectableFlags_HelpOutput(t *testing.T) {
-	var buf bytes.Buffer
-	flags := &reflectableFlags{
-		flags: []mockReflectFlag{
-			{Name: "output", Shorthand: "o", Usage: "Output file", Value: "string"},
-			{Name: "verbose", Usage: "Enable verbose output", Value: "bool"},
-			{Name: "help", Shorthand: "h", Usage: "Display the help message", Value: "bool"},
+		"non-func VisitAll": {
+			flags:      &nonFuncVisitAllFlags{},
+			wantResult: false,
 		},
-		out: &buf,
-	}
+		"non-struct callback": {
+			flags:      &stringVisitAllFlags{},
+			wantResult: true,
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			var visited []flagInfo
+			result := visitFlags(testData.flags, func(f flagInfo) {
+				visited = append(visited, f)
+			})
 
-	app := NewSingleCommandApp(testAppInfo, testNoOpExecutor, nil, io.Discard, io.Discard)
-	app.printFlagDefaults(flags)
+			if result != testData.wantResult {
+				t.Errorf("visitFlags returned %v, want %v", result, testData.wantResult)
+			}
 
-	got := buf.String()
-	want := "\nOptions:\n\n" +
-		"\t-o, --output string\tOutput file\n" +
-		"\t    --verbose      \tEnable verbose output\n" +
-		"\t-h, --help         \tDisplay the help message\n"
+			if len(visited) != len(testData.wantFlags) {
+				t.Fatalf("visitFlags visited %d flags, want %d", len(visited), len(testData.wantFlags))
+			}
 
-	if got != want {
-		t.Errorf("printFlagDefaults with reflectable flags gave %q, want %q", got, want)
+			for i, want := range testData.wantFlags {
+				if visited[i] != want {
+					t.Errorf("flag %d: got %+v, want %+v", i, visited[i], want)
+				}
+			}
+		})
 	}
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,7 +1,10 @@
 package lieut
 
 import (
+	"bytes"
 	"context"
+	"flag"
+	"fmt"
 	"io"
 	"testing"
 )
@@ -73,4 +76,282 @@ func TestBogusFlags_WorkWithMultiCommandApps(t *testing.T) {
 	app.PrintUsageError("", nil)
 	app.PrintUsageError("foo", nil)
 	app.Run(context.TODO(), nil)
+}
+
+// verboseBogusFlags is a Flags implementation without VisitAll that produces
+// output in PrintDefaults, used to test the fallback output path.
+type verboseBogusFlags struct {
+	out io.Writer
+}
+
+func (v *verboseBogusFlags) Parse(arguments []string) error { return nil }
+func (v *verboseBogusFlags) Args() []string                 { return nil }
+func (v *verboseBogusFlags) Output() io.Writer              { return v.out }
+func (v *verboseBogusFlags) SetOutput(output io.Writer)     { v.out = output }
+func (v *verboseBogusFlags) PrintDefaults() {
+	fmt.Fprintln(v.out, "  -someflag\tA flag description")
+}
+
+// mockFlagValue implements an interface with a Type() method, similar to
+// third-party flag library value types (like spf13/pflag).
+type mockFlagValue string
+
+func (m mockFlagValue) Type() string { return string(m) }
+
+// mockReflectFlag mimics a third-party flag struct with exported fields, used
+// to exercise the reflection-based visitor in visitFlags.
+type mockReflectFlag struct {
+	Name      string
+	Shorthand string
+	Usage     string
+	DefValue  string
+	Value     mockFlagValue
+}
+
+// reflectableFlags is a Flags implementation with a VisitAll method that uses a
+// non-standard callback signature, exercising the reflection-based visitor path
+// in visitFlags.
+type reflectableFlags struct {
+	flags []mockReflectFlag
+	out   io.Writer
+}
+
+func (r *reflectableFlags) Parse(arguments []string) error { return nil }
+func (r *reflectableFlags) Args() []string                 { return nil }
+func (r *reflectableFlags) PrintDefaults()                 {}
+func (r *reflectableFlags) Output() io.Writer              { return r.out }
+func (r *reflectableFlags) SetOutput(output io.Writer)     { r.out = output }
+func (r *reflectableFlags) VisitAll(fn func(*mockReflectFlag)) {
+	for i := range r.flags {
+		fn(&r.flags[i])
+	}
+}
+
+// minimalReflectFlag is a flag struct with only a Name field, used to test the
+// reflection visitor when expected fields are missing.
+type minimalReflectFlag struct {
+	Name string
+}
+
+// minimalReflectableFlags is a Flags implementation that visits flags with only
+// a Name field, exercising the missing-field fallback in visitFlags.
+type minimalReflectableFlags struct {
+	flags []minimalReflectFlag
+	out   io.Writer
+}
+
+func (m *minimalReflectableFlags) Parse(arguments []string) error { return nil }
+func (m *minimalReflectableFlags) Args() []string                 { return nil }
+func (m *minimalReflectableFlags) PrintDefaults()                 {}
+func (m *minimalReflectableFlags) Output() io.Writer              { return m.out }
+func (m *minimalReflectableFlags) SetOutput(output io.Writer)     { m.out = output }
+func (m *minimalReflectableFlags) VisitAll(fn func(*minimalReflectFlag)) {
+	for i := range m.flags {
+		fn(&m.flags[i])
+	}
+}
+
+// nonFuncVisitAllFlags has a VisitAll method with a non-function parameter,
+// used to test the reflection guard against non-func callback types.
+type nonFuncVisitAllFlags struct {
+	bogusFlags
+}
+
+func (n *nonFuncVisitAllFlags) VisitAll(name string) {}
+
+// stringVisitAllFlags has a VisitAll method that passes strings instead of
+// structs, used to test the reflection guard against non-struct values.
+type stringVisitAllFlags struct {
+	bogusFlags
+}
+
+func (s *stringVisitAllFlags) VisitAll(fn func(string)) {
+	fn("test-flag")
+}
+
+func TestPrintFlagDefaults_FallbackWithOutput(t *testing.T) {
+	var buf bytes.Buffer
+	flags := &verboseBogusFlags{out: &buf}
+
+	app := NewSingleCommandApp(testAppInfo, testNoOpExecutor, nil, io.Discard, io.Discard)
+	app.printFlagDefaults(flags)
+
+	got := buf.String()
+	want := "\nOptions:\n\n  -someflag\tA flag description\n"
+
+	if got != want {
+		t.Errorf("printFlagDefaults fallback with output gave %q, want %q", got, want)
+	}
+}
+
+func TestPrintFlagDefaults_EmptyFlagSet(t *testing.T) {
+	var buf bytes.Buffer
+	emptyFlags := flag.NewFlagSet("empty", flag.ContinueOnError)
+	emptyFlags.SetOutput(&buf)
+
+	app := NewSingleCommandApp(testAppInfo, testNoOpExecutor, nil, io.Discard, &buf)
+	app.printFlagDefaults(emptyFlags)
+
+	if buf.String() != "" {
+		t.Errorf("printFlagDefaults with empty flagset gave %q, want empty", buf.String())
+	}
+}
+
+func TestFormatFlagName(t *testing.T) {
+	for testName, testData := range map[string]struct {
+		f             flagInfo
+		dashPrefix    string
+		hasShorthands bool
+		want          string
+	}{
+		"simple": {
+			f:          flagInfo{name: "verbose"},
+			dashPrefix: "-",
+			want:       "-verbose",
+		},
+		"with type": {
+			f:          flagInfo{name: "output", typeName: "string"},
+			dashPrefix: "--",
+			want:       "--output string",
+		},
+		"bool type omitted": {
+			f:          flagInfo{name: "verbose", typeName: "bool"},
+			dashPrefix: "--",
+			want:       "--verbose",
+		},
+		"with shorthand": {
+			f:             flagInfo{name: "help", shorthand: "h"},
+			dashPrefix:    "--",
+			hasShorthands: true,
+			want:          "-h, --help",
+		},
+		"without shorthand in shorthand layout": {
+			f:             flagInfo{name: "version"},
+			dashPrefix:    "--",
+			hasShorthands: true,
+			want:          "    --version",
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			got := formatFlagName(testData.f, testData.dashPrefix, testData.hasShorthands)
+			if got != testData.want {
+				t.Errorf("formatFlagName gave %q, want %q", got, testData.want)
+			}
+		})
+	}
+}
+
+func TestVisitFlags_Reflection(t *testing.T) {
+	flags := &reflectableFlags{
+		flags: []mockReflectFlag{
+			{Name: "verbose", Usage: "Enable verbose output", DefValue: "false", Value: "bool"},
+			{Name: "output", Shorthand: "o", Usage: "Output file", Value: "string"},
+		},
+	}
+
+	var visited []flagInfo
+	result := visitFlags(flags, func(f flagInfo) {
+		visited = append(visited, f)
+	})
+
+	if !result {
+		t.Fatal("visitFlags returned false for reflectable flags")
+	}
+
+	if len(visited) != 2 {
+		t.Fatalf("visitFlags visited %d flags, want 2", len(visited))
+	}
+
+	if visited[0].name != "verbose" || visited[0].typeName != "bool" {
+		t.Errorf("first flag: got name=%q typeName=%q, want name=%q typeName=%q",
+			visited[0].name, visited[0].typeName, "verbose", "bool")
+	}
+
+	if visited[1].shorthand != "o" || visited[1].typeName != "string" {
+		t.Errorf("second flag: got shorthand=%q typeName=%q, want shorthand=%q typeName=%q",
+			visited[1].shorthand, visited[1].typeName, "o", "string")
+	}
+}
+
+func TestVisitFlags_MissingFields(t *testing.T) {
+	flags := &minimalReflectableFlags{
+		flags: []minimalReflectFlag{
+			{Name: "test"},
+		},
+	}
+
+	var visited []flagInfo
+	result := visitFlags(flags, func(f flagInfo) {
+		visited = append(visited, f)
+	})
+
+	if !result {
+		t.Fatal("visitFlags returned false for minimal reflectable flags")
+	}
+
+	if len(visited) != 1 {
+		t.Fatalf("visitFlags visited %d flags, want 1", len(visited))
+	}
+
+	if visited[0].name != "test" {
+		t.Errorf("flag name: got %q, want %q", visited[0].name, "test")
+	}
+
+	if visited[0].shorthand != "" || visited[0].usage != "" || visited[0].defValue != "" {
+		t.Errorf("flag should have empty fields for missing struct fields, got %+v", visited[0])
+	}
+}
+
+func TestVisitFlags_NonFuncVisitAll(t *testing.T) {
+	flags := &nonFuncVisitAllFlags{}
+
+	result := visitFlags(flags, func(f flagInfo) {
+		t.Error("visitor should not be called")
+	})
+
+	if result {
+		t.Error("visitFlags returned true for non-func VisitAll")
+	}
+}
+
+func TestVisitFlags_NonStructCallback(t *testing.T) {
+	flags := &stringVisitAllFlags{}
+
+	var visited int
+	result := visitFlags(flags, func(f flagInfo) {
+		visited++
+	})
+
+	if !result {
+		t.Error("visitFlags returned false for string VisitAll")
+	}
+
+	if visited != 0 {
+		t.Errorf("visitFlags visited %d flags, want 0 (non-struct args should be skipped)", visited)
+	}
+}
+
+func TestReflectableFlags_HelpOutput(t *testing.T) {
+	var buf bytes.Buffer
+	flags := &reflectableFlags{
+		flags: []mockReflectFlag{
+			{Name: "output", Shorthand: "o", Usage: "Output file", Value: "string"},
+			{Name: "verbose", Usage: "Enable verbose output", Value: "bool"},
+			{Name: "help", Shorthand: "h", Usage: "Display the help message", Value: "bool"},
+		},
+		out: &buf,
+	}
+
+	app := NewSingleCommandApp(testAppInfo, testNoOpExecutor, nil, io.Discard, io.Discard)
+	app.printFlagDefaults(flags)
+
+	got := buf.String()
+	want := "\nOptions:\n\n" +
+		"\t-o, --output string\tOutput file\n" +
+		"\t    --verbose      \tEnable verbose output\n" +
+		"\t-h, --help         \tDisplay the help message\n"
+
+	if got != want {
+		t.Errorf("printFlagDefaults with reflectable flags gave %q, want %q", got, want)
+	}
 }

--- a/integrations/spf13-pflag_test.go
+++ b/integrations/spf13-pflag_test.go
@@ -3,8 +3,9 @@ package integrations
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
-	"strings"
+	"runtime"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -68,6 +69,25 @@ func TestPFlag__WorkWithMultiCommandApps(t *testing.T) {
 }
 
 func TestPFlag_FlagOrder(t *testing.T) {
+	wantFormat := `Usage: test testing
+
+A test
+
+Options:
+
+  -my-flag string
+    	string My custom flag
+  -z-flag string
+    	string A flag at the end
+  -version
+    	Display the application version
+  -help
+    	Display the help message
+
+test vTest (%s/%s)
+`
+	want := fmt.Sprintf(wantFormat, runtime.GOOS, runtime.GOARCH)
+
 	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flagSet.String("my-flag", "", "My custom flag")
 	flagSet.String("z-flag", "", "A flag at the end")
@@ -77,39 +97,9 @@ func TestPFlag_FlagOrder(t *testing.T) {
 
 	app.PrintHelp()
 
-	output := buf.String()
-	t.Logf("Output:\n%s", output)
+	got := buf.String()
 
-	// Check order of flags in "Options:" section
-	optionsIdx := strings.Index(output, "Options:")
-	if optionsIdx == -1 {
-		t.Fatal("Options section not found")
-	}
-
-	optionsSection := output[optionsIdx:]
-	helpIdx := strings.Index(optionsSection, "-help")
-	myFlagIdx := strings.Index(optionsSection, "-my-flag")
-	versionIdx := strings.Index(optionsSection, "-version")
-	zFlagIdx := strings.Index(optionsSection, "-z-flag")
-
-	if helpIdx == -1 || myFlagIdx == -1 || versionIdx == -1 || zFlagIdx == -1 {
-		t.Fatalf(
-			"Flags not found: help=%d, my-flag=%d, version=%d, z-flag=%d",
-			helpIdx,
-			myFlagIdx,
-			versionIdx,
-			zFlagIdx,
-		)
-	}
-
-	// We expect: myFlag < zFlag < version < help
-	if !(myFlagIdx < zFlagIdx && zFlagIdx < versionIdx && versionIdx < helpIdx) {
-		t.Errorf(
-			"Unexpected flag order. Expected others < version < help. Got my-flag at %d, z-flag at %d, version at %d, help at %d",
-			myFlagIdx,
-			zFlagIdx,
-			versionIdx,
-			helpIdx,
-		)
+	if got != want {
+		t.Errorf("app.PrintHelp gave %q, want %q", got, want)
 	}
 }

--- a/integrations/spf13-pflag_test.go
+++ b/integrations/spf13-pflag_test.go
@@ -1,8 +1,10 @@
 package integrations
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -63,4 +65,51 @@ func TestPFlag__WorkWithMultiCommandApps(t *testing.T) {
 	app.PrintUsageError("", nil)
 	app.PrintUsageError("foo", nil)
 	app.Run(context.TODO(), nil)
+}
+
+func TestPFlag_FlagOrder(t *testing.T) {
+	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flagSet.String("my-flag", "", "My custom flag")
+	flagSet.String("z-flag", "", "A flag at the end")
+
+	var buf bytes.Buffer
+	app := lieut.NewSingleCommandApp(testAppInfo, testNoOpExecutor, flagSet, &buf, &buf)
+
+	app.PrintHelp()
+
+	output := buf.String()
+	t.Logf("Output:\n%s", output)
+
+	// Check order of flags in "Options:" section
+	optionsIdx := strings.Index(output, "Options:")
+	if optionsIdx == -1 {
+		t.Fatal("Options section not found")
+	}
+
+	optionsSection := output[optionsIdx:]
+	helpIdx := strings.Index(optionsSection, "-help")
+	myFlagIdx := strings.Index(optionsSection, "-my-flag")
+	versionIdx := strings.Index(optionsSection, "-version")
+	zFlagIdx := strings.Index(optionsSection, "-z-flag")
+
+	if helpIdx == -1 || myFlagIdx == -1 || versionIdx == -1 || zFlagIdx == -1 {
+		t.Fatalf(
+			"Flags not found: help=%d, my-flag=%d, version=%d, z-flag=%d",
+			helpIdx,
+			myFlagIdx,
+			versionIdx,
+			zFlagIdx,
+		)
+	}
+
+	// We expect: myFlag < zFlag < version < help
+	if !(myFlagIdx < zFlagIdx && zFlagIdx < versionIdx && versionIdx < helpIdx) {
+		t.Errorf(
+			"Unexpected flag order. Expected others < version < help. Got my-flag at %d, z-flag at %d, version at %d, help at %d",
+			myFlagIdx,
+			zFlagIdx,
+			versionIdx,
+			helpIdx,
+		)
+	}
 }

--- a/integrations/spf13-pflag_test.go
+++ b/integrations/spf13-pflag_test.go
@@ -75,14 +75,10 @@ A test
 
 Options:
 
-  -my-flag string
-    	string My custom flag
-  -z-flag string
-    	string A flag at the end
-  -version
-    	Display the application version
-  -help
-    	Display the help message
+	    --my-flag string	My custom flag
+	    --z-flag string 	A flag at the end
+	    --version       	Display the application version
+	-h, --help          	Display the help message
 
 test vTest (%s/%s)
 `

--- a/lieut_test.go
+++ b/lieut_test.go
@@ -260,12 +260,9 @@ A test
 
 Options:
 
-  -testflag string
-    	A test flag (default "testval")
-  -version
-    	Display the application version
-  -help
-    	Display the help message
+	-testflag string	A test flag (default "testval")
+	-version        	Display the application version
+	-help           	Display the help message
 
 test vTest (%s/%s)
 `
@@ -298,12 +295,9 @@ Commands:
 
 Options:
 
-  -testflag string
-    	A test flag (default "testval")
-  -version
-    	Display the application version
-  -help
-    	Display the help message
+	-testflag string	A test flag (default "testval")
+	-version        	Display the application version
+	-help           	Display the help message
 
 test vTest (%s/%s)
 `
@@ -346,12 +340,9 @@ A test command
 
 Options:
 
-  -testcommandflag int
-    	A test command flag (default 5)
-  -testflag string
-    	A test flag (default "testval")
-  -help
-    	Display the help message
+	-testcommandflag int	A test command flag (default 5)
+	-testflag string    	A test flag (default "testval")
+	-help               	Display the help message
 
 test vTest (%s/%s)
 `
@@ -401,10 +392,8 @@ Commands:
 
 Options:
 
-  -version
-    	Display the application version
-  -help
-    	Display the help message
+	-version	Display the application version
+	-help   	Display the help message
 
 test vTest (%s/%s)
 `
@@ -750,10 +739,8 @@ A test
 
 Options:
 
-  -version
-    	Display the application version
-  -help
-    	Display the help message
+	-version	Display the application version
+	-help   	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH)
@@ -787,10 +774,8 @@ A test
 
 Options:
 
-  -version
-    	Display the application version
-  -help
-    	Display the help message
+	-version	Display the application version
+	-help   	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH),
@@ -1071,8 +1056,7 @@ A test command
 
 Options:
 
-  -help
-    	Display the help message
+	-help	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH)
@@ -1111,10 +1095,8 @@ Commands:
 
 Options:
 
-  -version
-    	Display the application version
-  -help
-    	Display the help message
+	-version	Display the application version
+	-help   	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH),
@@ -1130,8 +1112,7 @@ A test command
 
 Options:
 
-  -help
-    	Display the help message
+	-help	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH),
@@ -1151,10 +1132,8 @@ Commands:
 
 Options:
 
-  -version
-    	Display the application version
-  -help
-    	Display the help message
+	-version	Display the application version
+	-help   	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH),

--- a/lieut_test.go
+++ b/lieut_test.go
@@ -260,12 +260,12 @@ A test
 
 Options:
 
-  -help
-    	Display the help message
   -testflag string
     	A test flag (default "testval")
   -version
     	Display the application version
+  -help
+    	Display the help message
 
 test vTest (%s/%s)
 `
@@ -298,12 +298,12 @@ Commands:
 
 Options:
 
-  -help
-    	Display the help message
   -testflag string
     	A test flag (default "testval")
   -version
     	Display the application version
+  -help
+    	Display the help message
 
 test vTest (%s/%s)
 `
@@ -346,12 +346,12 @@ A test command
 
 Options:
 
-  -help
-    	Display the help message
   -testcommandflag int
     	A test command flag (default 5)
   -testflag string
     	A test flag (default "testval")
+  -help
+    	Display the help message
 
 test vTest (%s/%s)
 `
@@ -401,10 +401,10 @@ Commands:
 
 Options:
 
-  -help
-    	Display the help message
   -version
     	Display the application version
+  -help
+    	Display the help message
 
 test vTest (%s/%s)
 `
@@ -750,10 +750,10 @@ A test
 
 Options:
 
-  -help
-    	Display the help message
   -version
     	Display the application version
+  -help
+    	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH)
@@ -787,10 +787,10 @@ A test
 
 Options:
 
-  -help
-    	Display the help message
   -version
     	Display the application version
+  -help
+    	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH),
@@ -1111,10 +1111,10 @@ Commands:
 
 Options:
 
-  -help
-    	Display the help message
   -version
     	Display the application version
+  -help
+    	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH),
@@ -1151,10 +1151,10 @@ Commands:
 
 Options:
 
-  -help
-    	Display the help message
   -version
     	Display the application version
+  -help
+    	Display the help message
 
 test vTest (%s/%s)
 `, runtime.GOOS, runtime.GOARCH),


### PR DESCRIPTION
## What?

This PR standardizes and polishes the `--help` output to provide a more professional, "paneled" CLI experience consistent with modern tools.


## Key Changes:

 - **Predictable Ordering:** Implemented logic to ensure the `--version` option always appears second to last and the `--help` option appears last, regardless of user-defined flags.
 - **Aligned Formatting:** Standardized the "Options" section to use a tab-aligned layout that matches the existing "Commands" section, ensuring all usage strings are perfectly column-aligned.
 - **Generic Library Support:** Added a robust, reflection-based visitor that transparently supports both the Go standard library and third-party packages like `pflag`. The printer automatically adjusts dash styles (single vs. double) and discovers shorthands and type names generically.